### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Context Protocol (MCP) server that provides tools to interact with the [
 
 Dash 8 is required, which is currently in beta. You can download Dash 8 at https://blog.kapeli.com/dash-8.
 
+<a href="https://glama.ai/mcp/servers/@Kapeli/dash-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Kapeli/dash-mcp-server/badge" alt="Dash Server MCP server" />
+</a>
+
 ## Overview
 
 The Dash MCP server provides tools for accessing and searching documentation directly from Dash, the macOS documentation browser. MCP clients can:


### PR DESCRIPTION
This PR adds a badge for the [Dash MCP Server](https://glama.ai/mcp/servers/@Kapeli/dash-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Kapeli/dash-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Kapeli/dash-mcp-server/badge" alt="Dash Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.