### PR TITLE
fix: wrap servers in mcpServers key in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,12 @@
 {
-    "dash-api": {
-        "command": "uvx",
-        "args": [
-            "--from",
-            "git+https://github.com/Kapeli/dash-mcp-server.git",
-            "dash-mcp-server"
-        ]
+    "mcpServers": {
+        "dash-api": {
+            "command": "uvx",
+            "args": [
+                "--from",
+                "git+https://github.com/Kapeli/dash-mcp-server.git",
+                "dash-mcp-server"
+            ]
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Claude Code (and other MCP clients following the standard config schema) reject `.mcp.json` with a parse error because the top level lacks the required `mcpServers` wrapper.
- Nest the existing `dash-api` entry under `mcpServers` so the project config parses successfully.

Before:
```json
{
    "dash-api": { ... }
}
```

After:
```json
{
    "mcpServers": {
        "dash-api": { ... }
    }
}
```

## Test plan
- [x] Run \`/doctor\` in Claude Code and confirm the project config parses without a schema error
- [x] Verify the \`dash-api\` server still launches via \`uvx\`